### PR TITLE
Add fade animation for menu toggle

### DIFF
--- a/contrib/gui/include/gui/controls/window.h
+++ b/contrib/gui/include/gui/controls/window.h
@@ -10,18 +10,19 @@ namespace evo::gui
 	class window : public control_container
 	{
 	public:
-		window(const control_id &id, const ren::vec2 &p, const ren::vec2 &s) : control_container(id, p, s)
-		{
-			using namespace ren;
+                window(const control_id &id, const ren::vec2 &p, const ren::vec2 &s) : control_container(id, p, s)
+                {
+                        using namespace ren;
 
-			is_window = true;
-			priority = ip_window;
-			sort = ++ctx->top_sort;
+                        is_window = true;
+                        priority = ip_window;
+                        sort = ++ctx->top_sort;
 
-			pfp_anim = std::make_shared<anim_float>(.0f, .15f);
-			src_anim = std::make_shared<anim_color>(colors.texts.disabled, .15f);
-			type = ctrl_window;
-		}
+                        pfp_anim = std::make_shared<anim_float>(.0f, .15f);
+                        src_anim = std::make_shared<anim_color>(colors.texts.disabled, .15f);
+                        alpha_anim = std::make_shared<anim_float>(0.f, .15f);
+                        type = ctrl_window;
+                }
 
 		void add(const std::shared_ptr<control> &c) override;
 
@@ -31,18 +32,21 @@ namespace evo::gui
 		void on_mouse_up(char key) override;
 		void on_mouse_move(const ren::vec2 &p, const ren::vec2 &d) override;
 
-		bool allow_move{true};
+                bool allow_move{true};
 
-	private:
-		ren::vec2 get_avatar_pos();
-		bool is_mouse_on_avatar{};
+                std::shared_ptr<ren::anim_float> alpha_anim; // fade animation
+                bool awaiting_hide{};
+
+        private:
+                ren::vec2 get_avatar_pos();
+                bool is_mouse_on_avatar{};
 
 		ren::vec2 get_search_pos();
 		bool is_mouse_on_search{};
 
-		std::shared_ptr<ren::anim_float> pfp_anim;
-		std::shared_ptr<ren::anim_color> src_anim;
-	};
+                std::shared_ptr<ren::anim_float> pfp_anim;
+                std::shared_ptr<ren::anim_color> src_anim;
+        };
 } // namespace evo::gui
 
 #endif // GUI_TESTER_WINDOW_H

--- a/gui_src/controls/window.cpp
+++ b/gui_src/controls/window.cpp
@@ -6,14 +6,26 @@ GUI_NAMESPACE;
 
 void window::render()
 {
-	pfp_anim->animate();
-	src_anim->animate();
+        pfp_anim->animate();
+        src_anim->animate();
+        if (alpha_anim)
+                alpha_anim->animate();
+
+        if (awaiting_hide && alpha_anim && alpha_anim->value == 0.f)
+        {
+                is_visible = false;
+                awaiting_hide = false;
+                return;
+        }
 
 	const auto r = area_abs();
 	const auto r_tab_line = r.margin_top(3.f).height(64.f);
 
-	auto &d = draw.layers[ctx->content_layer];
-	d->g.anti_alias = true;
+        auto &d = draw.layers[ctx->content_layer];
+        d->g.anti_alias = true;
+        const auto old_alpha_global = d->g.alpha;
+        if (alpha_anim)
+                d->g.alpha *= alpha_anim->value;
 
 	// background
 	d->add_rect_filled_rounded(r.padding_top(3.f), colors.base.gray_darkest, 3.f, rnd_b);
@@ -85,7 +97,9 @@ void window::render()
 	d->add_shadow_line(r_tab_line.margin_top(64.f).height(7.f), shadow_down, .1f);
 	d->g.anti_alias = false;
 
-	control_container::render();
+        control_container::render();
+
+        d->g.alpha = old_alpha_global;
 }
 
 void window::on_mouse_down(char key)

--- a/menu/menu.cpp
+++ b/menu/menu.cpp
@@ -270,50 +270,61 @@ void menu_manager::create()
 
 void menu_manager::toggle()
 {
-	if (const auto wnd = main_wnd.lock(); wnd && can_toggle)
-	{
-		wnd->is_visible = !wnd->is_visible;
-		wnd->is_taking_input = wnd->is_visible;
+        if (const auto wnd = main_wnd.lock(); wnd && can_toggle)
+        {
+                const bool open = !(wnd->is_visible && !wnd->awaiting_hide);
 
-		if (!wnd->is_visible)
-		{
-			ctx->active = nullptr;
-			for (const auto& p : ctx->active_popups)
-				p->close();
-		}
+                if (open)
+                {
+                        wnd->is_visible = true;
+                        wnd->awaiting_hide = false;
+                        if (wnd->alpha_anim)
+                                wnd->alpha_anim->direct(1.f);
+                }
+                else
+                {
+                        wnd->awaiting_hide = true;
+                        if (wnd->alpha_anim)
+                                wnd->alpha_anim->direct(0.f);
 
-		ctx->should_render_cursor = wnd->is_visible;
+                        ctx->active = nullptr;
+                        for (const auto& p : ctx->active_popups)
+                                p->close();
+                }
+
+                wnd->is_taking_input = open;
+                ctx->should_render_cursor = open;
 
 		const auto hotkeys = ctx->find(::gui::widgets::active_hotkeys_id);
 		if (hotkeys)
 		{
 			const auto wdg = hotkeys->as<widget>();
-			wdg->is_forced_visibility = wnd->is_visible;
-			wdg->is_taking_input = wnd->is_visible;
+                        wdg->is_forced_visibility = open;
+                        wdg->is_taking_input = open;
 		}
 
 		const auto indicators = ctx->find(::gui::widgets::indicators_id);
 		if (indicators)
 		{
 			const auto wdg = indicators->as<widget>();
-			wdg->is_forced_visibility = wnd->is_visible;
-			wdg->is_taking_input = wnd->is_visible;
+                        wdg->is_forced_visibility = open;
+                        wdg->is_taking_input = open;
 		}
 
 		const auto spectators = ctx->find(::gui::widgets::spectators_id);
 		if (spectators)
 		{
 			const auto wdg = spectators->as<widget>();
-			wdg->is_forced_visibility = wnd->is_visible;
-			wdg->is_taking_input = wnd->is_visible;
+                        wdg->is_forced_visibility = open;
+                        wdg->is_taking_input = open;
 		}
 
 		const auto bomb = ctx->find(::gui::widgets::bomb_id);
 		if (bomb)
 		{
 			const auto wdg = bomb->as<widget>();
-			wdg->is_forced_visibility = wnd->is_visible;
-			wdg->is_taking_input = wnd->is_visible;
+                        wdg->is_forced_visibility = open;
+                        wdg->is_taking_input = open;
 		}
 
 		if (!cfg.misc.menu_movement.get())


### PR DESCRIPTION
## Summary
- enable alpha animation on the menu window
- trigger fade when toggling the menu visibility

## Testing
- `make -n` *(fails: No makefile)*

------
https://chatgpt.com/codex/tasks/task_e_685c6afac83083249ad9892d74a146c3